### PR TITLE
fix: support file-based components in dependency resolution and remote downloads

### DIFF
--- a/python/cldpm/commands/get.py
+++ b/python/cldpm/commands/get.py
@@ -8,6 +8,25 @@ from typing import Optional
 
 import click
 
+
+def _find_component_path(base_dir: Path, dep_type: str, dep_name: str) -> Optional[Path]:
+    """Find a component path, checking both directory and file variants.
+
+    Components can be directories (e.g., shared/skills/logging/) or
+    files (e.g., shared/skills/new-skill.md). This function checks
+    the exact path first, then looks for file matches with extensions.
+    """
+    exact = base_dir / dep_type / dep_name
+    if exact.exists():
+        return exact
+    # Look for file with extension (e.g., new-skill.md)
+    parent = base_dir / dep_type
+    if parent.exists():
+        for item in parent.iterdir():
+            if item.stem == dep_name and item.is_file():
+                return item
+    return None
+
 from ..core.config import load_cldpm_config
 from ..core.resolver import resolve_project
 from ..utils.fs import ensure_dir, find_repo_root
@@ -207,10 +226,12 @@ def _download_local_project(
     for dep_type in ["skills", "agents", "hooks", "rules"]:
         for component in resolved["shared"].get(dep_type, []):
             comp_name = component["name"]
-            source_comp = shared_dir / dep_type / comp_name
-            target_comp = target_path / ".claude" / dep_type / comp_name
+            source_comp = _find_component_path(shared_dir, dep_type, comp_name)
+            if source_comp is None:
+                continue
+            target_comp = target_path / ".claude" / dep_type / source_comp.name
 
-            if source_comp.exists() and not target_comp.exists():
+            if not target_comp.exists():
                 if source_comp.is_dir():
                     shutil.copytree(source_comp, target_comp)
                 else:
@@ -334,11 +355,15 @@ def _handle_remote_get_sparse(
         cleanup_temp_dir(temp_project)
 
         # Build path list for final sparse clone
+        # Include both directory and file patterns for each dependency
+        # since components can be directories (e.g., shared/skills/logging/)
+        # or files (e.g., shared/skills/new-skill.md)
         all_paths = [project_path]
         dependencies = project_config.get("dependencies", {})
         for dep_type in ["skills", "agents", "hooks", "rules"]:
             for dep_name in dependencies.get(dep_type, []):
                 all_paths.append(f"{shared_dir}/{dep_type}/{dep_name}")
+                all_paths.append(f"{shared_dir}/{dep_type}/{dep_name}.*")
 
         # Phase 3: Download everything needed
         console.print(f"[dim]Downloading project and dependencies...[/dim]")
@@ -478,8 +503,10 @@ def _build_sparse_result(
     for dep_type in ["skills", "agents", "hooks", "rules"]:
         result["shared"][dep_type] = []
         for dep_name in dependencies.get(dep_type, []):
-            source_comp = temp_dir / shared_dir / dep_type / dep_name
-            if source_comp.exists():
+            source_comp = _find_component_path(
+                temp_dir / shared_dir, dep_type, dep_name
+            )
+            if source_comp:
                 # Get list of files in the component
                 if source_comp.is_dir():
                     files = [f.name for f in source_comp.iterdir() if f.is_file()]
@@ -488,7 +515,7 @@ def _build_sparse_result(
                 result["shared"][dep_type].append({
                     "name": dep_name,
                     "type": "shared",
-                    "sourcePath": f"{shared_dir}/{dep_type}/{dep_name}",
+                    "sourcePath": f"{shared_dir}/{dep_type}/{source_comp.name}",
                     "files": files,
                 })
 
@@ -576,10 +603,14 @@ def _download_sparse_project(
     # Place shared components directly in .claude/<type>/<name>/
     for dep_type in ["skills", "agents", "hooks", "rules"]:
         for dep_name in dependencies.get(dep_type, []):
-            source_comp = temp_dir / shared_dir / dep_type / dep_name
-            target_comp = target / ".claude" / dep_type / dep_name
+            source_comp = _find_component_path(
+                temp_dir / Path(shared_dir), dep_type, dep_name
+            )
+            if source_comp is None:
+                continue
+            target_comp = target / ".claude" / dep_type / source_comp.name
 
-            if source_comp.exists() and not target_comp.exists():
+            if not target_comp.exists():
                 ensure_dir(target_comp.parent)
                 if source_comp.is_dir():
                     shutil.copytree(source_comp, target_comp)
@@ -678,10 +709,12 @@ def _download_remote_project(
     for dep_type in ["skills", "agents", "hooks", "rules"]:
         for component in resolved["shared"].get(dep_type, []):
             comp_name = component["name"]
-            source_comp = shared_dir / dep_type / comp_name
-            target_comp = target / ".claude" / dep_type / comp_name
+            source_comp = _find_component_path(shared_dir, dep_type, comp_name)
+            if source_comp is None:
+                continue
+            target_comp = target / ".claude" / dep_type / source_comp.name
 
-            if source_comp.exists() and not target_comp.exists():
+            if not target_comp.exists():
                 if source_comp.is_dir():
                     shutil.copytree(source_comp, target_comp)
                 else:

--- a/python/cldpm/utils/git.py
+++ b/python/cldpm/utils/git.py
@@ -256,17 +256,24 @@ def sparse_clone_paths(
             sparse_cmd, cwd=temp_clone, check=True, capture_output=True, env=env
         )
 
-        # Step 3: Copy files to target (excluding .git)
+        # Step 3: Copy sparse checkout to target (excluding .git)
+        # Skip broken symlinks during copy (they can't be resolved)
+        def _ignore_broken_symlinks_and_git(directory, contents):
+            ignored = []
+            for item in contents:
+                if item == ".git":
+                    ignored.append(item)
+                    continue
+                item_path = Path(directory) / item
+                if item_path.is_symlink() and not item_path.resolve().exists():
+                    ignored.append(item)
+            return ignored
+
         target_dir.mkdir(parents=True, exist_ok=True)
-        for path in paths:
-            src = temp_clone / path
-            if src.exists():
-                dst = target_dir / path
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                if src.is_dir():
-                    shutil.copytree(src, dst, dirs_exist_ok=True)
-                else:
-                    shutil.copy2(src, dst)
+        shutil.copytree(
+            temp_clone, target_dir, dirs_exist_ok=True,
+            ignore=_ignore_broken_symlinks_and_git,
+        )
     finally:
         shutil.rmtree(temp_clone, ignore_errors=True)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cldpm"
-version = "0.1.6"
+version = "0.1.7"
 description = "Claude Project Manager - SDK and CLI for mono repo management with Claude Code projects"
 readme = "README.md"
 license = "MIT"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cldpm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cldpm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cldpm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Claude Project Manager - SDK and CLI for mono repo management with Claude Code projects",
   "type": "module",
   "main": "./dist/index.js",

--- a/typescript/src/commands/get.ts
+++ b/typescript/src/commands/get.ts
@@ -26,6 +26,34 @@ import type { ResolvedProject } from "../core/resolver.js";
 import type { ResolvedComponent } from "../schemas/index.js";
 
 /**
+ * Find a component path, checking both directory and file variants.
+ * Components can be directories (e.g., shared/skills/logging/) or
+ * files (e.g., shared/skills/new-skill.md).
+ */
+function findComponentPath(baseDir: string, depType: string, depName: string): string | null {
+  const exact = path.join(baseDir, depType, depName);
+  try {
+    fsSync.accessSync(exact);
+    return exact;
+  } catch {
+    // Look for file with extension
+    const parent = path.join(baseDir, depType);
+    try {
+      const entries = fsSync.readdirSync(parent);
+      for (const entry of entries) {
+        const parsed = path.parse(entry);
+        if (parsed.name === depName && fsSync.statSync(path.join(parent, entry)).isFile()) {
+          return path.join(parent, entry);
+        }
+      }
+    } catch {
+      // parent doesn't exist
+    }
+  }
+  return null;
+}
+
+/**
  * Copy a directory recursively, resolving symlinks to actual files
  */
 async function copyDir(src: string, dest: string, resolveSymlinks = true): Promise<void> {
@@ -265,6 +293,7 @@ async function handleRemoteGetSparse(
       const deps = dependencies[depType] || [];
       for (const depName of deps) {
         allPaths.push(`${sharedDir}/${depType}/${depName}`);
+        allPaths.push(`${sharedDir}/${depType}/${depName}.*`);
       }
     }
 
@@ -427,7 +456,12 @@ function buildSparseResult(
   for (const depType of depTypes) {
     const deps = dependencies[depType] || [];
     for (const depName of deps) {
-      const sourceComp = path.join(tempDir, sharedDir, depType, depName);
+      const sourceComp = findComponentPath(
+        path.join(tempDir, sharedDir), depType, depName
+      );
+      if (!sourceComp) {
+        continue;
+      }
       // Get list of files in the component
       let files: string[] = [];
       try {
@@ -438,7 +472,7 @@ function buildSparseResult(
             return fstat.isFile();
           });
         } else if (stat.isFile()) {
-          files = [depName];
+          files = [path.basename(sourceComp)];
         }
       } catch {
         // Component doesn't exist
@@ -447,7 +481,7 @@ function buildSparseResult(
       result.shared[depType].push({
         name: depName,
         type: "shared",
-        sourcePath: `${sharedDir}/${depType}/${depName}`,
+        sourcePath: `${sharedDir}/${depType}/${path.basename(sourceComp)}`,
         files,
       });
     }
@@ -610,26 +644,26 @@ async function downloadSparseProject(
   for (const depType of depTypes) {
     const deps = dependencies[depType] || [];
     for (const depName of deps) {
-      const sourceComp = path.join(tempDir, sharedDir, depType, depName);
-      const targetComp = path.join(target, ".claude", depType, depName);
+      const sourceComp = findComponentPath(
+        path.join(tempDir, sharedDir), depType, depName
+      );
+      if (!sourceComp) {
+        continue;
+      }
+      const targetComp = path.join(target, ".claude", depType, path.basename(sourceComp));
 
       try {
-        await fs.access(sourceComp);
-        try {
-          await fs.access(targetComp);
-          // Already exists, skip
-        } catch {
-          // Doesn't exist, copy
-          await fs.mkdir(path.dirname(targetComp), { recursive: true });
-          const stat = await fs.stat(sourceComp);
-          if (stat.isDirectory()) {
-            await copyDir(sourceComp, targetComp, false);
-          } else {
-            await fs.copyFile(sourceComp, targetComp);
-          }
-        }
+        await fs.access(targetComp);
+        // Already exists, skip
       } catch {
-        // Source doesn't exist, skip
+        // Doesn't exist, copy
+        await fs.mkdir(path.dirname(targetComp), { recursive: true });
+        const stat = await fs.stat(sourceComp);
+        if (stat.isDirectory()) {
+          await copyDir(sourceComp, targetComp, false);
+        } else {
+          await fs.copyFile(sourceComp, targetComp);
+        }
       }
     }
   }

--- a/typescript/src/utils/git.ts
+++ b/typescript/src/utils/git.ts
@@ -168,13 +168,27 @@ export async function cleanupTempDir(tempDir: string): Promise<void> {
 /**
  * Copy a directory recursively.
  */
-async function copyDir(src: string, dest: string): Promise<void> {
+async function copyDir(src: string, dest: string, exclude?: string): Promise<void> {
   await fs.mkdir(dest, { recursive: true });
   const entries = await fs.readdir(src, { withFileTypes: true });
 
   for (const entry of entries) {
+    if (exclude && entry.name === exclude) {
+      continue;
+    }
+
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
+
+    // Skip broken symlinks
+    const lstats = await fs.lstat(srcPath);
+    if (lstats.isSymbolicLink()) {
+      try {
+        await fs.stat(srcPath); // follows symlink, throws if target missing
+      } catch {
+        continue; // broken symlink, skip
+      }
+    }
 
     if (entry.isDirectory()) {
       await copyDir(srcPath, destPath);
@@ -229,25 +243,9 @@ export async function sparseClonePaths(
     const sparseArgs = ["sparse-checkout", "set", "--no-cone", ...paths];
     await execCommand("git", sparseArgs, { cwd: tempClone });
 
-    // Step 3: Copy files to target (excluding .git)
+    // Step 3: Copy entire sparse checkout to target (excluding .git)
     await fs.mkdir(targetDir, { recursive: true });
-    for (const p of paths) {
-      const src = path.join(tempClone, p);
-      try {
-        await fs.access(src);
-        const dst = path.join(targetDir, p);
-        await fs.mkdir(path.dirname(dst), { recursive: true });
-
-        const stat = await fs.stat(src);
-        if (stat.isDirectory()) {
-          await copyDir(src, dst);
-        } else {
-          await fs.copyFile(src, dst);
-        }
-      } catch {
-        // Path doesn't exist in repo, skip
-      }
-    }
+    await copyDir(tempClone, targetDir, ".git");
   } finally {
     await cleanupTempDir(tempClone);
   }


### PR DESCRIPTION
## Summary                                                                                                                        
  - Fix dependency resolution to discover individual files (e.g., `agents/coordinator.md`) as components, not just directories
  - Fix remote sparse clone to fetch and download file-based shared components (e.g., `shared/skills/new-skill.md`)                 
  - Fix `shutil.copytree` crash on broken symlinks during sparse clone copy                                                         
  - Detect symlinked items in `.claude/` as shared dependencies even when not listed in `project.json` dependencies                 
  - Update docs to reflect that components can be directories or single files                                                       
                                                                                                                                    
  ## Changes                                                                                                                        
                                                                                                                                    
  ### Dependency Resolution (TypeScript & Python `resolver.ts` / `resolver.py`)                                                     
  - `resolveComponent` / `resolveLocalComponent` — handle file paths instead of failing on `readdir`
  - `getLocalComponentsInProject` — pick up files alongside directories, classify symlinks as shared                                
  - `listSharedComponents` — include files in component listing                                                                     
  - `resolveProject` — merge symlink-discovered shared components into results                                                      
                                                                                                                                    
  ### Remote Sparse Clone (TypeScript & Python `get.ts` / `get.py`)                                                                 
  - Add `.*` glob patterns to sparse checkout paths so file-based deps (e.g., `new-skill.md`) are fetched                           
  - Copy entire sparse checkout tree instead of path-by-path (fixes glob patterns not being real paths)                             
  - Add `findComponentPath` / `_find_component_path` helper to resolve dep names to actual files with extensions                    
  - Update `buildSparseResult` and all download functions to use the helper                                                         
                                                                                                                                    
  ### Broken Symlink Handling (TypeScript & Python `git.ts` / `git.py`)                                                             
  - Skip broken symlinks during `copytree` / `copyDir` instead of crashing with ENOENT                                              
                                                                                                                                    
  ### Docs
  - Updated README, concepts, CLI get, Python SDK/README with file component examples                                               
                                                                                                                                    
  ## Test plan
  - [x] TypeScript: 101 tests pass                                                                                                  
  - [x] Python: 171 tests pass                              
  - [x] `cldpm get testing -d -o ./output -r https://github.com/AmanAgarwal041/test-cldpm -b test/cldpm-slash` — downloads
  `new-skill.md`, `new-agent.md` (shared files) and `helper-agent.md` (local file)                                                  
  - [x] Verified both TypeScript and Python CLI produce identical downloads
  - [x] Verify `cldpm get -d` local download with file-based shared deps